### PR TITLE
Ensure that popstate event handler is removed when skrollr is destroyed

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -155,7 +155,7 @@
 		skrollr.addEvent(document, 'click', handleClick);
 
 		if(supportsHistory) {
-			window.addEventListener('popstate', function(e) {
+			skrollr.addEvent(window, 'popstate', function(e) {
 				var state = e.state || {};
 				var top = state.top || 0;
 


### PR DESCRIPTION
Destroying Skrollr with this plugin initialised breaks any internal links in (at least) Chrome on OSX 10.8; any link scrolls to the top instead of the desired anchor.

This pull request: skrollr.addEvent is used instead of adding the event directly to window, which makes sure it gets removed when it should be.
