### PR TITLE
Add function to get scroll item's position

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -77,11 +77,12 @@
 
 		var menuTop = null;
 
-        if(!_handleLink) //If there's a data-menu-top attribute and no handleLink function, it overrides the actuall anchor offset.
-            menuTop = link.getAttribute(MENU_TOP_ATTR);
-        else //If there's a handleLink function, it overrides the actuall anchor offset
-        	menuTop = _handleLink(link);
-        	
+		if(!_handleLink) { //If there's a data-menu-top attribute and no handleLink function, it overrides the actuall anchor offset.
+			menuTop = link.getAttribute(MENU_TOP_ATTR);
+		} else { //If there's a handleLink function, it overrides the actuall anchor offset
+			menuTop = _handleLink(link);
+		}
+
 		if(menuTop !== null) {
 			targetTop = +menuTop;
 		} else {
@@ -146,8 +147,8 @@
 		_easing = options.easing || DEFAULT_EASING;
 		_animate = options.animate !== false;
 		_duration = options.duration || DEFAULT_DURATION;
-        _handleLink = options.handleLink;
-                
+		_handleLink = options.handleLink;
+
 		if(typeof _duration === 'number') {
 			_duration = (function(duration) {
 				return function() {


### PR DESCRIPTION
Usage example : 

```
skrollr.menu.init(app.skrollr.instance, {
                    animate: true,
                    easing: 'sqrt',
                    duration: function(currentTop, targetTop){
                        return 1000;
                    },
                    itemPosFunction: function(){
                        var href = $(this).attr('href');
                        if(app.isMobile())
                            return app.skrollr.instance.getScrollTop() + $(href).offset().top - $(href).height() - 40;

                        return $(href).offset().top - $(href).height() - 40;
                    }
                });
```
