### PR TITLE
Check Active Link Href

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -61,6 +61,7 @@
 
 	var getLinkTargetTop = function(link)
 	{
+		var href = link.getAttribute('href');
 		var targetTop;
 
 		var menuTop = 0;


### PR DESCRIPTION
Just a idea for check the active link by href attribute. Works with several menu containing the same links.

Usage example : 

```
skrollr.menu.init(app.skrollr.instance, {
    [...]
    activeSubstract: function(link) {
        var href = $(link).attr('href');
        if(href == '#services') return 180;
        else return 80;
    },
    [...]
});

$(window).scroll(function(){
    $('#navigation a[href='+skrollr.menu.getActiveHref()+']').addClass('active');
});
```
