### PR TITLE
Added handy skrollr.menu.scrollTo(fragment) API

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -176,6 +176,20 @@
 
 		jumpStraightToHash();
 	};
+    /*
+        Scroll to a specified URL fragment, with or without the `#` prefix.
+        /!\ You must have somewhere in the page an anchor that points to it.
+        @param string hash An URL fragment to scroll to
+     */
+    skrollr.menu.scrollTo = function(fragment) {
+        if(!_skrollrInstance) throw "Please run skrollr.menu.init() first";
+        if(fragment.substr(0,1) != '#') fragment = '#' + fragment;
+        var link = document.querySelector('a[href="' + fragment + '"]');
+
+        if(link) {
+            handleLink(link, true);
+        }
+    };
 
 	//Private reference to the initialized skrollr.
 	var _skrollrInstance;


### PR DESCRIPTION
Not really clean, but quick and handy.
PITFALL : If no anchor pointing to specified fragment exist, nothing happens.
