### PR TITLE
Ignore events handled by other listeners

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -43,6 +43,11 @@
 		Handle the click event on the document.
 	*/
 	var handleClick = function(e) {
+		//Ignore prevented events
+		if(e.defaultPrevented) {
+			return;
+		}
+
 		//Only handle left click.
 		if(e.which !== 1 && e.button !== 0) {
 			return;


### PR DESCRIPTION
Avoid scrolling if link is used by a third-party. E.g. if I use Twitter Bootstrap with the carousel-component in to show images, I do not want my page to start scrolling when users click next/prev.

Related to https://github.com/Prinzhorn/skrollr/pull/474
