### PR TITLE
Fix skrollr-menu handling unwanted links

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -68,9 +68,10 @@
 		//Don't use the href property (link.href) because it contains the absolute url.
 		var href = link.getAttribute('href');
 		var clazz = link.getAttribute('class');
+		var validClazz = !(clazz===null) && (clazz.trim().length > 0);
 
 		//Check if it's a hashlink.
-		if(!/^#/.test(href) || (clazz===null) || (clazz && clazz.indexOf(_menuLinkClass)==-1)) {
+		if(!/^#/.test(href) || (!validClazz) || (validClazz && clazz.indexOf(_menuLinkClass)==-1)) {
 			return false;
 		}
 


### PR DESCRIPTION
Permits to specify the class for those links that need to be handled by the skrollr-menu component, avoiding it to threat other links the same way.
