### PR TITLE
Accept nonpresent links

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -139,7 +139,7 @@
 				link = document.createElement('a');
 				link.href = window.location.hash;
 			}
-			
+
 			handleLink(link, true);
 		}
 	};


### PR DESCRIPTION
Currently, if the page is loaded with a hashlink for which the target element is present on the page but there is no link to it present, skrollr-menu will prevent the browser from scrolling to the element as it should, but not replicate the functionality. 
This commit will create a link to the correct element and then activate it if there is not already a link present. 
