### PR TITLE
Accept nonstandard links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,20 @@ skrollr.menu.init(s, {
 	//You are in control where skrollr will scroll to. You get the clicked link as a parameter and are expected to return a number.
 	handleLink: function(link) {
 		return 400;//Hardcoding 400 doesn't make much sense.
-	}
+    },
+    
+    //By default, skrollr-menu will only intercept links where href == '#yourElementID' exactly. 
+    //If you enable this option, it will also trim away GET options and the current URL, i.e. the 
+    // following will all work (if the user is on the correct page):
+    // 'http://example.com/currentPage/#elementID',
+    // 'http://example.com/currentDir/currentPage.html?foo=bar#elementID'
+    // '/?foo=bar#elementID'
+    //BEWARE: Some CMS systems use GET parameters to differentiate pages. If this option is enabled, 
+    // skrollr-menu will treat all such pages as the same page. 
+    complexLinks: false
 });
 ```
-
+ 
 And in order to fix the problem with the wrong offset, you are able to specify the target scroll position right at the link, e.g.
 
 ```html

--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -68,9 +68,29 @@
 		//Don't use the href property (link.href) because it contains the absolute url.
 		var href = link.getAttribute('href');
 
-		//Check if it's a hashlink.
-		if(!/^#/.test(href)) {
-			return false;
+		// If we're only looking for simple hashlinks
+		if(!_complexLinks) {
+
+			// Look for a # at the start of the link's href
+			if(!/^#/.test(href)) {
+				return false;
+			}
+
+		} else { // Else, attempt to identify links pointing to this page
+
+			// Look for a # present in the link's href
+			if(!/#/.test(href)) {
+				return false;
+			}
+
+			// Check if it's for this page & domain
+			if( !(link.hostname == document.location.hostname && link.pathname == document.location.pathname) ) {
+				return false;
+			}
+
+			// Having done the checks & determined that the link is for this page,
+			//  now load the simple hashlink into href. 
+			href = link.hash;
 		}
 
 		//Now get the targetTop to scroll to.
@@ -158,6 +178,7 @@
 		_duration = options.duration || DEFAULT_DURATION;
 		_handleLink = options.handleLink;
 		_scale = options.scale || DEFAULT_SCALE;
+		_complexLinks = options.complexLinks === true;
 
 		if(typeof _duration === 'number') {
 			_duration = (function(duration) {
@@ -198,6 +219,7 @@
 	var _animate;
 	var _handleLink;
 	var _scale;
+	var _complexLinks;
 
 	//In case the page was opened with a hash, prevent jumping to it.
 	//http://stackoverflow.com/questions/3659072/jquery-disable-anchor-jump-when-loading-a-page


### PR DESCRIPTION
## Issue

Currently skrollr-menu will not animate / deal with any hashlinks to the current page unless they are expressed with `href='#xxx'`. This means that absolute links to the current page with hash-links will fail when clicked from that page. 
## Example

The menu of a site has a link with `href='/#mysection'`. This will fail because the preceding `/` causes skrollr-menu not to parse it, even though it should be considered a valid link. 
## Changes

This commit addresses this by including a function to check if a link points to the current page, and also supports any GET parameters that a clicked hash-link may have. 
