### PR TITLE
Specify animation duration on individual links

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 			<li><a href="#wambo">150px before #wambo</a></li>
 			<li><a href="#section1" data-menu-top="1000">1000 pixels down</a></li>
 			<li><a href="#awesome" data-menu-top="75p">75% down</a></li>
+			<li><a href="#awesome" data-menu-duration="5000">#awesome over 5 seconds</a></li>
 		</ul>
 
 		<p>Biltong pastrami kielbasa short ribs, turducken shoulder pork chop boudin ground round speck cow. Fatback leberkas shank hamburger, tail pork belly tongue bresaola short ribs corned beef speck tri-tip ribeye. Filet mignon shoulder speck pastrami. Ham hock turducken corned beef shankle. Meatloaf shankle sausage boudin, shank flank turducken tenderloin pancetta ball tip. Biltong boudin jowl drumstick pig.</p>

--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -15,6 +15,7 @@
 
 	var MENU_TOP_ATTR = 'data-menu-top';
 	var MENU_OFFSET_ATTR = 'data-menu-offset';
+	var MENU_DURATION_ATTR = 'data-menu-duration';
 
 	var skrollr = window.skrollr;
 	var history = window.history;
@@ -132,10 +133,17 @@
 			history.pushState({top: targetTop}, '', hash);
 		}
 
+		var menuDuration = parseInt(link.getAttribute(MENU_DURATION_ATTR), 10);
+		var animationDuration = _duration(_skrollrInstance.getScrollTop(), targetTop);
+
+		if(!isNaN(menuDuration)) {
+			animationDuration = menuDuration;
+		}
+
 		//Now finally scroll there.
 		if(_animate && !fake) {
 			_skrollrInstance.animateTo(targetTop, {
-				duration: _duration(_skrollrInstance.getScrollTop(), targetTop),
+				duration: animationDuration,
 				easing: _easing
 			});
 		} else {


### PR DESCRIPTION
Adds support for data-menu-duration attribute

@@ -15,6 +15,7 @@
Add MENU_DURATION_ATTR variable

@@ -132,10 +133,18 @@
Check if MENU_DURATION_ATTR atrribute is set on link.
If so, set animationDuration to attribute value, else use _duration() function

Proposed Documentation:
## Duration

To specify a set duration for the animation on a specific link, use the `data-menu-duration` attribute. This allows for fine-grain control between presentation slides, for example, where one slide may have more animation than others.

``` html
<a href="#target-element" data-menu-duration="2000">Link to target element</a>
```

[edit: updated markup example]

In this example, the transition to the #target-element anchor will take 2 seconds, over-riding the default.
