### PR TITLE
a hook for the hashchange 

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -131,11 +131,12 @@
 
 		if(supportsHistory && !fake) {
 			history.pushState({top: targetTop}, '', hash);
-			// please, let me a chance to know if the hash has changed
-			if ( typeof _skrollrInstance.onHashChange === 'function' ) {
-                            _skrollrInstance.onHashChange(hash);
-                        }
 		}
+		
+		// please, let me a chance to know if the hash has changed
+		if ( typeof _skrollrInstance.onHashChange === 'function' ) {
+                        _skrollrInstance.onHashChange(hash);
+                }
 
 		var menuDuration = parseInt(link.getAttribute(MENU_DURATION_ATTR), 10);
 		var animationDuration = _duration(_skrollrInstance.getScrollTop(), targetTop);

--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -131,6 +131,10 @@
 
 		if(supportsHistory && !fake) {
 			history.pushState({top: targetTop}, '', hash);
+			// please, let me a chance to know if the hash has changed
+			if ( typeof _skrollrInstance.onHashChange === 'function' ) {
+                            _skrollrInstance.onHashChange(hash);
+                        }
 		}
 
 		var menuDuration = parseInt(link.getAttribute(MENU_DURATION_ATTR), 10);


### PR DESCRIPTION
I want know when the hash change, so i propose these change.

and use it like that:
```
            // Init Skrollr
            s = skrollr.init();
            skrollr.menu.init();

            s.onHashChange = function(hash) {
                    jQuery(window).trigger('hashchange'); // yeah !!! i can catch hashchange event !!!
            };           
```