### PR TITLE
Option to omit adding hash link to URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ skrollr.menu.init(s, {
 	//This event is triggered right before we jump/animate to a new hash.
 	change: function(newHash, newTopPosition) {
 		//Do stuff
-	}
+	},
+	
+	//Add hash link (e.g. `#foo`) to URL or not.
+	updateUrl: false //defaults to `true`.
 });
 ```
 

--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -135,7 +135,7 @@
 			}
 		}
 
-		if(supportsHistory && !fake) {
+		if(supportsHistory && _updateUrl && !fake) {
 			history.pushState({top: targetTop}, '', hash);
 		}
 
@@ -200,6 +200,7 @@
 		_scale = options.scale || DEFAULT_SCALE;
 		_complexLinks = options.complexLinks === true;
 		_change = options.change;
+		_updateUrl = options.updateUrl !== false;
 
 		if(typeof _duration === 'number') {
 			_duration = (function(duration) {
@@ -242,6 +243,7 @@
 	var _scale;
 	var _complexLinks;
 	var _change;
+	var _updateUrl;
 
 	//In case the page was opened with a hash, prevent jumping to it.
 	//http://stackoverflow.com/questions/3659072/jquery-disable-anchor-jump-when-loading-a-page


### PR DESCRIPTION
Concerning: #3 
On small one pager websites it might be better not to add the fragment identifier to the URL. People often first explore the page (using those jump links) and decide after a while to bookmark it. Coming back later on, they probably don't expect to jump to "#foo" right where they left the page. I think `skrollr-menu` should at least *offer* this option!
(Great work – btw!)