### PR TITLE
fix findParentLink

### DIFF
--- a/src/skrollr.menu.js
+++ b/src/skrollr.menu.js
@@ -28,7 +28,7 @@
 	*/
 	var findParentLink = function(element) {
 		//We reached the top, no link found.
-		if(element === document) {
+		if(element === document || !element) {
 			return false;
 		}
 


### PR DESCRIPTION
`findParentLink` doesn't properly handle elements that don't belong to the document tree, which could cause error when user remove an element in click event handler.

Example: https://jsfiddle.net/toruta39/ysdvsnLt/1/